### PR TITLE
make browserify-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,19 @@
 {
   "name": "youtube-video-js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Easily play and control Youtube video using javascript",
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ]
+        }
+      ]
+    ]
+  },  
   "repository": {
     "type": "git",
     "url": "https://github.com/mkay581/youtube-video-js.git"
@@ -21,6 +33,9 @@
   "main": "src/youtube-video.js",
   "devDependencies": {
     "babel-polyfill": "^6.7.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babelify": "^7.3.0",
+    "browserify": "^13.0.1",
     "build-tools": "^3.0.2",
     "sinon": "^1.17.3"
   },


### PR DESCRIPTION
hiiiiii thx for this module ! :)

in this PR, i've added `browserify`, `babelify`, and the `babel-preset-es2015` shim. 

now `youtube-video-js` can be bundled with `browserify` and used like so:

```js
import YoutubeVideo from 'youtube-video-js'

var video = new YoutubeVideo({
  el: document.getElementsByTagName('video')[0]
})
```