### PR TITLE
Fix iframe positioning on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
   ],
   "main": "src/youtube-video.js",
   "devDependencies": {
-    "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-polyfill": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "build-tools": "^4.1.3",
     "sinon": "^1.17.3"
   },
   "dependencies": {
+    "babel-preset-es2015": "^6.16.0",
     "lodash": "^4.8.2",
     "promise": "^7.1.1",
     "resource-manager-js": "^1.2.1"

--- a/src/youtube-video.js
+++ b/src/youtube-video.js
@@ -135,6 +135,10 @@ class YoutubeVideo  {
         container.setAttribute('class', this.options.customWrapperClass);
         instance.container = container;
 
+        // make original video element absolute or it will
+        // push the newly created video div down
+        this.options.el.style.position = 'absolute';
+
         if (origParent && origParent.contains(this.el)) {
             origParent.replaceChild(container, this.el);
         }


### PR DESCRIPTION
Fixes an issue where original `<video>` element was pushing the iframe down too far out of view, making it appear as though the video wasn't loaded.