### PR TITLE
Support native playsline attribute

### DIFF
--- a/src/youtube-video.ts
+++ b/src/youtube-video.ts
@@ -65,6 +65,10 @@ export class YoutubeVideoElement extends HTMLElement {
         return Boolean(this.getAttribute('autoplay'));
     }
 
+    get playsinline(): boolean {
+        return Boolean(this.getAttribute('playsinline'));
+    }
+
     get id(): string {
         return this.getAttribute('id') || `ytPlayer-${videos.size}`;
     }
@@ -77,6 +81,7 @@ export class YoutubeVideoElement extends HTMLElement {
         const { srcQueryParams } = this;
         srcQueryParams.autoplay = this.autoplay ? 1 : 0;
         srcQueryParams.controls = this.controls ? 1 : 0;
+        srcQueryParams.playsinline = this.playsinline ? 1 : 0;
         return srcQueryParams;
     }
 

--- a/tests/youtube-video-tests.ts
+++ b/tests/youtube-video-tests.ts
@@ -134,6 +134,22 @@ describe('Youtube Video Tests', function() {
         assert.equal(constructorOptionArgs.playerVars.autoplay, 1);
     });
 
+    it('should pass playsinline option of 1 to Youtube player constructor if autoplay attr is true on video element', async function() {
+        var videoId = 'nOEw9iiopwI';
+        const videoEl = document.createElement(
+            'youtube-video'
+        ) as YoutubeVideoElement;
+        videoEl.setAttribute(
+            'src',
+            `http://www.youtube.com/watch?v=${videoId}`
+        );
+        videoEl.setAttribute('playsinline', 'true');
+        testContainer.appendChild(videoEl);
+        await videoEl.load();
+        const [, constructorOptionArgs] = fakePlayerConstructor.args[0];
+        assert.equal(constructorOptionArgs.playerVars.playsinline, 1);
+    });
+
     it('should trigger appropriate events on video element when youtube player api triggers its events', async function() {
         const videoEl = document.createElement(
             'youtube-video'


### PR DESCRIPTION
This updates the package so that setting the [`playsinline` attribute](https://html.spec.whatwg.org/multipage/media.html#attr-video-playsinline) will properly send `1` as the parameter to the Youtube API. 

```html
<youtube-video
    width="640"
    height="360"
    src="https://www.youtube.com/watch?v=Wn9twYUXw6w"
    playsinline
></youtube-video>
```
See [Youtube's `playsinline` parameter documentation](https://developers.google.com/youtube/player_parameters#playsinline) for more information.

