### PR TITLE
Pass origin to YT Player API

### DIFF
--- a/src/youtube-video.ts
+++ b/src/youtube-video.ts
@@ -82,6 +82,7 @@ export class YoutubeVideoElement extends HTMLElement {
         srcQueryParams.autoplay = this.autoplay ? 1 : 0;
         srcQueryParams.controls = this.controls ? 1 : 0;
         srcQueryParams.playsinline = this.playsinline ? 1 : 0;
+        srcQueryParams.origin = window.location.origin;
         return srcQueryParams;
     }
 

--- a/tests/youtube-video-tests.ts
+++ b/tests/youtube-video-tests.ts
@@ -303,6 +303,10 @@ describe('Youtube Video Tests', function () {
         var [, ytPlayerConstructorOptions] = fakePlayerConstructor.args[0];
         assert.equal(ytPlayerConstructorOptions.playerVars.v, params.v);
         assert.equal(ytPlayerConstructorOptions.playerVars.my, params.my);
+        assert.equal(
+            ytPlayerConstructorOptions.playerVars.origin,
+            window.location.origin
+        );
     });
 
     it('attempting to play/pause a video before player has loaded does not throw an mediaError', async function () {


### PR DESCRIPTION
Youtube's recommendation on its [iFrame Player API page](https://developers.google.com/youtube/iframe_api_reference):

> While `origin` is optional, including it protects against malicious third-party JavaScript being injected into your page and hijacking control of your YouTube player.

Additionally this fixes the following error shown in the console when `origin` is not passed:

```bash
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://www.youtube.com') does not match the recipient window's origin.
```