### PR TITLE
Make sizes strings so caller can can use percentages

### DIFF
--- a/src/youtube-video.ts
+++ b/src/youtube-video.ts
@@ -56,11 +56,11 @@ export class YoutubeVideoElement extends HTMLElement {
         }
     }
 
-    get height(): number {
-        return Number(this.getAttribute('height'));
+    get height(): string {
+        return this.getAttribute('height');
     }
-    get width(): number {
-        return Number(this.getAttribute('width'));
+    get width(): string {
+        return this.getAttribute('width');
     }
 
     get src(): string {


### PR DESCRIPTION
This change lets callers use percentages for height and width so they can dynamically resize for different screen sizes.

Example:
```html
// using percentages
<youtube-video height="100%" width="100%" src="..." controls></youtube-video>

// using exact values
<youtube-video height="800" width="500" src="..." controls></youtube-video>
```